### PR TITLE
Updated selectable table so it works with Symphony 2.4

### DIFF
--- a/content/content.edit.php
+++ b/content/content.edit.php
@@ -114,7 +114,15 @@
 			$table_head = Widget::TableHead(array(array(__('Tags'), 'col'), array(__('Frequency'), 'col')));
 			$table_body = Widget::TableBody($table_rows);
 
-			$this->Form->appendChild(Widget::Table($table_head, null, $table_body, 'selectable'));
+			$table = Widget::Table(
+				$table_head,
+				NULL,
+				$table_body,
+				'selectable',
+				null,
+				array('role' => 'directory', 'aria-labelledby' => 'symphony-subheading', 'data-interactive' => 'data-interactive')
+			);
+			$this->Form->appendChild($table);
 
 			$options = array(
 				array(null, false, 'With Selected...'),

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -16,6 +16,11 @@
 	</authors>
 
 	<releases>
+	<release version="1.0.2" date="2014-06-22">
+			<![CDATA[
+			- 2.4 fix
+			]]>
+		</release>
 		<release version="1.0.1" date="2012-12-31">
 			<![CDATA[
 			- Added Russian translation, courtesy [alexbirukov](https://github.com/alexbirukov)


### PR DESCRIPTION
This may have been an issue in earlier versions, but it was definitely an issue in 2.4. Tables were no longer selectable (requiring more than just the class), changing the way the table was built fixed it.
